### PR TITLE
Update Demo dependencies to latest

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -7,19 +7,19 @@
     "test": "jest"
   },
   "dependencies": {
-    "prop-types": "~15.6.1",
-    "react": "16.3.1",
-    "react-native": "0.55.3",
-    "react-native-animatable": "~1.2.4",
-    "react-native-fbsdk": "~0.7.0",
-    "react-native-google-signin": "~0.12.0",
-    "react-navigation": "~2.0.1"
+    "prop-types": "~15.7.2",
+    "react": "16.13.1",
+    "react-native": "0.63.3",
+    "react-native-animatable": "~1.3.3",
+    "react-native-fbsdk": "~2.0.0",
+    "react-native-google-signin": "~2.1.1",
+    "react-navigation": "~4.4.1"
   },
   "devDependencies": {
-    "babel-jest": "22.4.3",
-    "babel-preset-react-native": "4.0.0",
-    "jest": "22.4.3",
-    "react-test-renderer": "16.3.1"
+    "babel-jest": "26.3.0",
+    "babel-preset-react-native": "4.0.1",
+    "jest": "26.4.2",
+    "react-test-renderer": "16.13.1"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
Updated dependencies:

```
 prop-types                  ~15.6.1  →  ~15.7.2   
 react                        16.3.1  →  16.13.1   
 react-native                 0.55.3  →   0.63.3   
 react-native-animatable      ~1.2.4  →   ~1.3.3   
 react-native-fbsdk           ~0.7.0  →   ~2.0.0   
 react-native-google-signin  ~0.12.0  →   ~2.1.1   
 react-navigation             ~2.0.1  →   ~4.4.1   
 babel-jest                   22.4.3  →   26.3.0   
 babel-preset-react-native     4.0.0  →    4.0.1   
 jest                         22.4.3  →   26.4.2   
 react-test-renderer          16.3.1  →  16.13.1   
```